### PR TITLE
Rollback bundler to 1.13.6

### DIFF
--- a/2.3-0/Dockerfile
+++ b/2.3-0/Dockerfile
@@ -2,6 +2,10 @@ FROM ruby:2.3
 MAINTAINER James Christianson <jamchri@microsoft.com>
 RUN apt-get update -qq && apt-get install -y nodejs unzip --no-install-recommends
 
+# Rollback bundler version for deployment reasons (14 had a breaking change for us)
+RUN  gem uninstall -i /usr/local/lib/ruby/gems/2.3.0 bundler
+RUN gem install bundler --version "=1.13.6"
+
 # Install passenger
 RUN gem install rubygems-bundler
 RUN gem regenerate_binstubs 


### PR DESCRIPTION
New version breaks deployment scenario