### PR TITLE
Get correct version of freetds for activerecord-sqlserver-adapter.

### DIFF
--- a/base_images/2.3.3/Dockerfile
+++ b/base_images/2.3.3/Dockerfile
@@ -45,12 +45,12 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz \
-    && tar zxvf freetds-patched.tar.gz \
-    && cd `tar -tzf freetds-patched.tar.gz | head -1 | cut -f1 -d"/"` \
-    && ./configure --sysconfdir=/etc/freetds \
-    && make; make install; make clean \
-    && cd ..
+RUN wget -O freetds-1.00.15.tar.gz "ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.15.tar.gz" \
+  && tar -xzvf freetds-1.00.15.tar.gz \
+  && cd freetds-1.00.15 \
+  && ./configure \
+  && make; make install; make clean \
+  && cd ..
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle

--- a/base_images/2.3.3/Dockerfile
+++ b/base_images/2.3.3/Dockerfile
@@ -45,7 +45,12 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz \
+    && tar zxvf freetds-patched.tar.gz \
+    && cd `tar -tzf freetds-patched.tar.gz | head -1 | cut -f1 -d"/"` \
+    && ./configure --sysconfdir=/etc/freetds \
+    && make; make install; make clean \
+    && cd ..
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle


### PR DESCRIPTION
activerecord-sqlserver-adapter depends on tiny_tds -v '2.1.2' which in turn requires FreeTDS 0.95.80 or higher.

The version of freetds-bin installed with apt-get on jessie is 0.91-6 (which is too low).
https://packages.debian.org/jessie/freetds-bin

tiny-tds docs recommend installing freetds from ftp.
https://github.com/rails-sqlserver/tiny_tds#install

Installing freetds this way lets `gem install activerecord-sqlserver-adapter` work.

relates to #10 