### PR TITLE
manually install version of freeTDS

### DIFF
--- a/base_images/2.3.3/Dockerfile
+++ b/base_images/2.3.3/Dockerfile
@@ -54,7 +54,18 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+RUN apt-get install -y unixodbc-dev
+
+# find latest version of FreeTDS ftp://ftp.freetds.org/pub/freetds/stable/
+ENV FREETDS_VERSION=1.1.6
+RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz \
+  && tar -xzf freetds-$FREETDS_VERSION.tar.gz \
+  && rm freetds-$FREETDS_VERSION.tar.gz \
+  && cd freetds-$FREETDS_VERSION \
+  && ./configure --prefix=/usr/local --with-tdsver=7.3 \
+  && make \
+  && make install \
+  && cd ..
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle

--- a/base_images/2.3.8/Dockerfile
+++ b/base_images/2.3.8/Dockerfile
@@ -54,7 +54,18 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+RUN apt-get install -y unixodbc-dev 
+
+# find latest version of FreeTDS ftp://ftp.freetds.org/pub/freetds/stable/
+ENV FREETDS_VERSION=1.1.6
+RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz \
+  && tar -xzf freetds-$FREETDS_VERSION.tar.gz \
+  && rm freetds-$FREETDS_VERSION.tar.gz \
+  && cd freetds-$FREETDS_VERSION \
+  && ./configure --prefix=/usr/local --with-tdsver=7.3 \
+  && make \
+  && make install \
+  && cd ..
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle

--- a/base_images/2.4.5/Dockerfile
+++ b/base_images/2.4.5/Dockerfile
@@ -54,7 +54,19 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+RUN apt-get install -y unixodbc-dev
+
+# find latest version of FreeTDS ftp://ftp.freetds.org/pub/freetds/stable/
+ENV FREETDS_VERSION=1.1.6
+RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz \
+  && tar -xzf freetds-$FREETDS_VERSION.tar.gz \
+  && rm freetds-$FREETDS_VERSION.tar.gz \
+  && cd freetds-$FREETDS_VERSION \
+  && ./configure --prefix=/usr/local --with-tdsver=7.3 \
+  && make \
+  && make install \
+  && cd ..
+
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle

--- a/base_images/2.5.5/Dockerfile
+++ b/base_images/2.5.5/Dockerfile
@@ -54,7 +54,18 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+RUN apt-get install -y unixodbc-dev
+
+# find latest version of FreeTDS ftp://ftp.freetds.org/pub/freetds/stable/
+ENV FREETDS_VERSION=1.1.6
+RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz \
+  && tar -xzf freetds-$FREETDS_VERSION.tar.gz \
+  && rm freetds-$FREETDS_VERSION.tar.gz \
+  && cd freetds-$FREETDS_VERSION \
+  && ./configure --prefix=/usr/local --with-tdsver=7.3 \
+  && make \
+  && make install \
+  && cd ..
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle

--- a/base_images/2.6.2/Dockerfile
+++ b/base_images/2.6.2/Dockerfile
@@ -54,7 +54,18 @@ RUN eval "$(rbenv init -)" \
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
 # SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+RUN apt-get install -y unixodbc-dev
+
+# find latest version of FreeTDS ftp://ftp.freetds.org/pub/freetds/stable/
+ENV FREETDS_VERSION=1.1.6
+RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-$FREETDS_VERSION.tar.gz \
+  && tar -xzf freetds-$FREETDS_VERSION.tar.gz \
+  && rm freetds-$FREETDS_VERSION.tar.gz \
+  && cd freetds-$FREETDS_VERSION \
+  && ./configure --prefix=/usr/local --with-tdsver=7.3 \
+  && make \
+  && make install \
+  && cd ..
 
 # Make temp directory for ruby images
 RUN mkdir -p /tmp/bundle


### PR DESCRIPTION
Changes pulled from https://github.com/Azure-App-Service/ruby-template/blob/dev/template/Dockerfile to fix error on deploy of tiny_tds gem to Azure app service on bundle install to all app versions.

`Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
current directory: /tmp/bundle/gems/tiny_tds-2.1.2/ext/tiny_tds
/usr/local/.rbenv/versions/2.4.5/bin/ruby -r ./siteconf20200203-331-1acoqp.rb
extconf.rb
checking for sybfront.h... no
checking for sybdb.h... no
checking for tdsdbopen() in -lsybdb... no
checking for dbanydatecrack() in -lsybdb... no
Failed! Do you have FreeTDS 0.95.80 or higher installed?
*** extconf.rb failed ***`
---------------------------
* [x ] Are these changes auto-generated from [ruby-template](https://github.com/Azure-App-Service/ruby-template)
* [x ] Have you made the same changes to [ruby-template](https://github.com/Azure-App-Service/ruby-template)
